### PR TITLE
docs: clean up CHANGELOG for 1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0] - 2026-02-26
+## [1.3.9] - 2026-06-17
 
 ### Added
-- Capacitor 8 Support.
-- Native SDK dependencies updated (`Sahha` iOS to `1.3.5`, `sahha-android` Android to `1.2.1`).
-- Exported missing `postSensorData` method for Capacitor iOS bridge.
-- Full bridging implementation of `getProfileToken` and `deauthenticate` on Android.
+
+- 93 new `SahhaSensor` types matching the native 1.3.9 SDKs: 39 nutrition, 15 reproductive, and 39 symptom sensors.
 
 ### Changed
-- Required compileSdkVersion and targetSdkVersion updated to 35 on Android.
-- Required Java version updated to 21 on Android.
-- Required Kotlin version updated to 1.9.25 on Android.
-- Required iOS Deployment Target updated to iOS 15.0.
-- Re-architected JSON serialization for Native bridge variables to support deeply nested responses from the Capacitor SDK (`getScores`, `getBiomarkers`, `getStats`, `getSamples`).
+
+- Updated the `Sahha` iOS SDK dependency to `1.3.9`.
+- Updated the `sahha-android` (`ai.sahha.android:sahha-api`) Android SDK dependency to `1.3.9`.
+- Removed the `energy_consumed` sensor from `SahhaSensor` (removed from the native SDK; superseded by `energy_intake`).
 
 ### Fixed
-- Fixed hanging promises on void-returning functions (`postSensorData`, `openAppSettings`) where they previously stalled JS `await` statements because `call.resolve()` was missing natively.
-- Fixed iOS Demographics SDK bridge mapping that previously caused an iOS hard-crash on compile targeting `SahhaDemographic.age` and other removed SDK fields.
+
+- _None._


### PR DESCRIPTION
Replaces the stale `2.0.0` placeholder entry with a clean `1.3.9` entry for this release, using the standard Added / Changed / Fixed headings.

### Added

- 93 new `SahhaSensor` types matching the native 1.3.9 SDKs (39 nutrition, 15 reproductive, 39 symptom).

### Changed

- iOS `Sahha` → `1.3.9`, Android `sahha-api` → `1.3.9`.
- Removed `energy_consumed` (superseded by `energy_intake`).

### Fixed

- _None._

---

Note: the previous `2.0.0` block (Capacitor 8 migration notes) was removed as requested. If you'd like that history preserved, I can re-add it as a `1.3.8` entry below `1.3.9`.